### PR TITLE
Bug fixed to show 6th Comrade's contact no. (Issue #34)

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -56,6 +56,8 @@ public class Trustees extends AppCompatActivity {
         comrade3editText.setText(sharedpreferences.getString(comrade3, ""));
         comrade4editText.setText(sharedpreferences.getString(comrade4, ""));
         comrade5editText.setText(sharedpreferences.getString(comrade5, ""));
+        comrade6editText.setText(sharedpreferences.getString(comrade6, ""));
+
 
         okButton.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
As mentioned in the issue, there was a bug that the contact number of the 6th comrade was not shown in the Trustees.java Activity. This was occurring because the editText for the 6th comrade was not being updated in the onCreate method.

Fixed the bug by adding a statement to update the text inside the editText. 