### PR TITLE
Fixed message sending feature (Issue #39)

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -106,10 +106,10 @@ public class CircleOfTrustFragment extends Fragment {
             // The numbers variable holds the Comrades numbers
             String numbers[] = {sharedPreferences.getString(Trustees.comrade1, ""), sharedPreferences.getString(Trustees.comrade2, ""),
                     sharedPreferences.getString(Trustees.comrade3, ""), sharedPreferences.getString(Trustees.comrade4, ""),
-                    sharedPreferences.getString(Trustees.comrade5, ""), sharedPreferences.getString(Trustees.comrade6, ""),};
+                    sharedPreferences.getString(Trustees.comrade5, ""), sharedPreferences.getString(Trustees.comrade6, "")};
 
             for(String number : numbers) {
-                if(number != ""){
+                if(!number.isEmpty()){
                     sms.sendTextMessage(number, null, message, null, null);
                 }
             }


### PR DESCRIPTION
In CircleOfTrustFragment.java , strings have been compared for nullity using != operator which is the incorrect way of comparing strings and hence gives incorrect result.Now the strings are checked for nullity by using  isEmpty(), which solves the problem.