### PR TITLE
Activated Web and Email links (Issue #44)

### DIFF
--- a/app/src/main/res/layout/textview.xml
+++ b/app/src/main/res/layout/textview.xml
@@ -12,4 +12,5 @@
         android:fadeScrollbars="false"
         android:layout_marginBottom="@dimen/activity_vertical_margin"
         android:autoLink="web|email"
+        android:textColorLink="#024002"
     />

--- a/app/src/main/res/layout/textview.xml
+++ b/app/src/main/res/layout/textview.xml
@@ -10,4 +10,6 @@
         android:padding="10dp"
         android:scrollbars="vertical"
         android:fadeScrollbars="false"
-        android:layout_marginBottom="@dimen/activity_vertical_margin"/>
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:autoLink="web|email"
+    />


### PR DESCRIPTION
Web links now on getting clicked , open up the respective page in the default web browser. The email links on being clicked open up in 'Compose email ' section of gmail, with the clicked email address as the destination.
Link color has also been changed so that they appear active to the users.