### PR TITLE
Add location details to Come get me

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.peacecorps.pcsa" >
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/peacecorps/pcsa/Constants.java
+++ b/app/src/main/java/com/peacecorps/pcsa/Constants.java
@@ -9,4 +9,8 @@ public class Constants {
         public static final String CALL_NEED_INTERRUPTION = "Call I need an interruption";
         public static final String NEED_TO_TALK = "I need to talk";
     }
+
+    public static final String TAG_LOCATION = "#LOC#";
+    public static final String TAG_LOCATION_URL = "#LOC_URL#";
+    public static final String LOCATION_URL = "http://maps.google.com/?q=LAT,LON";
 }

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/LocationHelper.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/LocationHelper.java
@@ -1,0 +1,96 @@
+package com.peacecorps.pcsa.circle_of_trust;
+
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.util.Log;
+
+/**
+ * Helper Class for handling location listening and retrieving
+ * Created by chamika on 2/29/16.
+ */
+public class LocationHelper {
+    public static final String LOCATION_PROVIDER = LocationManager.GPS_PROVIDER;
+    private static final String TAG = LocationHelper.class.getSimpleName();
+
+    private Location lastLocation;
+    private LocationManager locationManager;
+    private LocationListener locationListener;
+    private Context context;
+
+    public LocationHelper(Context context) {
+        this.context = context;
+    }
+
+    /**
+     * Start acquiring location updates
+     */
+    public void startAcquiringLocation() {
+        if (context != null) {
+            if (locationManager == null) {
+                // Acquire a reference to the system Location Manager
+                locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+            }
+
+            if (locationListener == null) {
+                // Define a listener that responds to location updates
+                locationListener = new LocationListener() {
+                    public void onLocationChanged(Location location) {
+                        // Called when a new location is found by the location provider.
+                        Log.d(TAG, "Location Updated:" + location.toString());
+                        updateLocation(location);
+                    }
+
+                    public void onStatusChanged(String provider, int status, Bundle extras) {
+                    }
+
+                    public void onProviderEnabled(String provider) {
+                    }
+
+                    public void onProviderDisabled(String provider) {
+                    }
+                };
+            }
+
+            try {
+                // Register the listener with the Location Manager to receive location updates
+                locationManager.requestLocationUpdates(LOCATION_PROVIDER, 0, 0, locationListener);
+            } catch (IllegalArgumentException e) {
+                Log.e(TAG, "Unable to listen to GPS location updates", e);
+            } catch (NullPointerException e) {
+                Log.e(TAG, "Unable to get location services", e);
+            }
+        }
+    }
+
+    /**
+     * Stop acquiring location updates.
+     * This is important to call to save battery consumption of retrieving GPS
+     */
+    public void stopAcquiringLocation() {
+        if (locationManager != null && locationListener != null) {
+            // Remove the listener which added by calling #startAcquiringLocation
+            locationManager.removeUpdates(locationListener);
+        }
+    }
+
+    /**
+     * Retrive acquired location
+     *
+     * @param needLastKnown if no location update found, return last known location
+     * @return
+     */
+    public Location retrieveLocation(boolean needLastKnown) {
+        if (lastLocation == null && locationManager != null && needLastKnown) {
+            lastLocation = locationManager.getLastKnownLocation(LOCATION_PROVIDER);
+        }
+        return lastLocation;
+    }
+
+    private void updateLocation(Location location) {
+        this.lastLocation = location;
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="need_to_talk">I need to talk</string>
     <string name="cancel">cancel</string>
     <string name="come_get_me_message">Come and get me. I need help getting home Safely. Call ASAP to get my Location.Sent through First Aide\'s Circle of Trust.</string>
+    <string name="come_get_me_message_with_location">Come and get me. I need help getting home Safely. My last location #LOC# ( #LOC_URL# ).Sent through First Aide\'s Circle of Trust.</string>
     <string name="interruption_message">Call and pretend you need me. I need an interruption. Message sent through First Aide\'s Circle of Trust</string>
     <string name="need_to_talk_message">I need to talk. Message sent through First Aide\'s Circle of Trust</string>
     <string name="comrade1_number">+2348103425729</string>


### PR DESCRIPTION
- Add latitude and longtitude in "Come get me" SMS.
SMS will be retrived from `strings.xml`. If need to add location to SMS body use #LOC# tag. If need to add google maps location url use #LOC_URL#.
Ex: "Come and get me. I need help getting home Safely. My last location #LOC# ( #LOC_URL# ).Sent through First Aide's Circle of Trust"
will send a message like 
"Come and get me. I need help getting home Safely. My last location 7.02044678,79.92049256 ( http://maps.google.com/?q=7.02044678,79.92049256 ).Sent through First Aide's Circle of Trust."

- Fix issue in sending SMS to Comrades' numbers if the SMS is longer than 160 characters
- Add location retrieving over GPS within circle of trust screen

Fix for #51 