### PR TITLE
Fix for Circle of Trust introduction second slide

### DIFF
--- a/app/src/main/res/layout/intro2.xml
+++ b/app/src/main/res/layout/intro2.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#00BCD4"
+    android:background="#018e9f"
     android:layout_weight="10"
     android:id="@+id/main">
 
@@ -16,8 +16,8 @@
         android:fontFamily="sans-serif-thin"
         android:textColor="#ffffff"
         android:paddingRight="32dp"
-        android:textSize="@dimen/text_normal"
-        android:text="When you are feeling insecure or needs a comrades attention.\nPrees the button"/>
+        android:textSize="@dimen/text_large"
+        android:text="@string/circle_of_trust_slide_two"/>
 
     <LinearLayout
         android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,5 +131,6 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
+    <string name="circle_of_trust_slide_two">When you are feeling insecure or needs a comrades attention.\nPress the button</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,6 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
-    <string name="circle_of_trust_slide_two">When you are feeling insecure or needs a comrades attention.\nPress the button</string>
+    <string name="circle_of_trust_slide_two">When you are feeling insecure or needs a comrades\' attention.\nPress the button</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,6 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
-    <string name="circle_of_trust_slide_two">When you are feeling insecure or needs a comrades\' attention.\nPress the button</string>
+    <string name="circle_of_trust_slide_two">When you are feeling insecure or need a comrades\' attention.\nPress the button</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,6 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
-    <string name="circle_of_trust_slide_two">When you are feeling insecure or need a comrades\' attention.\nPress the button</string>
+    <string name="circle_of_trust_slide_two">When you are feeling insecure or need comrades\' attention.\nPress the button</string>
 
 </resources>


### PR DESCRIPTION
Fix UI issue in text in the Circle of Trust introduction second slide by making text larger and background color darker
Change spelling mistake in Press

![screenshot_2016-02-29-23-44-42](https://cloud.githubusercontent.com/assets/754909/13404989/7103538e-df42-11e5-9588-b86012ebb5fd.png)

