### PR TITLE
User notified when no comrade is registered. (Issue #52)

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -152,19 +152,35 @@ public class CircleOfTrustFragment extends Fragment {
             // The numbers variable holds the Comrades numbers
             String numbers[] = phoneNumbers;
 
+            int counter=0;
             for(String number : numbers) {
                 if (!number.isEmpty()) {
                     sms.sendTextMessage(number, null, message, null, null);
+                    counter++;
                 }
             }
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-            builder.setTitle(R.string.msg_sent); // title bar string
-            builder.setPositiveButton(R.string.ok, null);
+            if(counter!=0)
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.msg_sent); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
 
-            builder.setMessage(getString(R.string.confirmation_message));
+                builder.setMessage(getString(R.string.confirmation_message));
 
-            AlertDialog errorDialog = builder.create();
-            errorDialog.show(); // display the Dialog
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+
+            }
+            else
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.no_comrade_title); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
+
+                builder.setMessage(R.string.no_comrade_msg);
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+            }
 
         }catch (Exception e)
         {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,5 +130,8 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
+    <string name="no_comrade_title">No Comrades Registered</string>
+    <string name="no_comrade_msg">Message not send to any comrade, since none is registered</string>
+
 
 </resources>


### PR DESCRIPTION
If no comrade have been added and the user presses the help me button, then a dialog box appears notifying the user that no message has been sent since no comrades were registered.

![screenshot_2016-03-01-01-56-51](https://cloud.githubusercontent.com/assets/8321130/13407954/18fc44ca-df51-11e5-807b-d48510d4ddfe.png)