### PR TITLE
Display the number of comrades to whom message is sent

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -152,19 +152,36 @@ public class CircleOfTrustFragment extends Fragment {
             // The numbers variable holds the Comrades numbers
             String numbers[] = phoneNumbers;
 
+            int counter=0;
             for(String number : numbers) {
                 if (!number.isEmpty()) {
                     sms.sendTextMessage(number, null, message, null, null);
+                    counter++;
                 }
             }
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-            builder.setTitle(R.string.msg_sent); // title bar string
-            builder.setPositiveButton(R.string.ok, null);
+            if(counter!=0)
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.msg_sent); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
 
-            builder.setMessage(getString(R.string.confirmation_message));
+                builder.setMessage(getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message2));
 
-            AlertDialog errorDialog = builder.create();
-            errorDialog.show(); // display the Dialog
+
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+
+            }
+            else
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.no_comrade_title); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
+
+                builder.setMessage(R.string.no_comrade_msg);
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+            }
 
         }catch (Exception e)
         {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,9 +126,13 @@
     <string name="comrade2_number">+2348111875720</string>
     <string name="msg_sent">Message sent</string>
     <string name="ok">OK</string>
-    <string name="confirmation_message">This message has been sent to all registered Comrades</string>
+    <string name="confirmation_message1">This message has been sent to</string>
+    <string name="confirmation_message2">registered Comrades</string>
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
+    <string name="no_comrade_title">No Comrades Registered</string>
+    <string name="no_comrade_msg">Message not send to any comrade, since none is registered</string>
+
 
 </resources>


### PR DESCRIPTION
In the confirmation dialog displayed after the messages are sent,  the number of comrades to whom the message has been sent is displayed now
![screenshot_2016-03-01-02-22-37](https://cloud.githubusercontent.com/assets/8321130/13409305/5e92eb0e-df58-11e5-84a2-04c1979d7512.png)
