### PR TITLE
User notified when no comrade is registered. (Issue #52)

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -182,7 +182,9 @@ public class CircleOfTrustFragment extends Fragment {
             int counter=0;
             for(String number : numbers) {
                 if (!number.isEmpty()) {
-                    sms.sendTextMessage(number, null, message, null, null);
+                    //Fix sending messages if the length is more than single sms limit
+                    ArrayList<String> parts = sms.divideMessage(message);
+                    sms.sendMultipartTextMessage(number, null, parts, null, null);
                     counter++;
                 }
             }

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -179,21 +179,36 @@ public class CircleOfTrustFragment extends Fragment {
             // The numbers variable holds the Comrades numbers
             String numbers[] = phoneNumbers;
 
+            int counter=0;
             for(String number : numbers) {
                 if (!number.isEmpty()) {
-                    //Fix sending messages if the length is more than single sms limit
-                    ArrayList<String> parts = sms.divideMessage(message);
-                    sms.sendMultipartTextMessage(number, null, parts, null, null);
+                    sms.sendTextMessage(number, null, message, null, null);
+                    counter++;
                 }
             }
-            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-            builder.setTitle(R.string.msg_sent); // title bar string
-            builder.setPositiveButton(R.string.ok, null);
+            if(counter!=0)
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.msg_sent); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
 
-            builder.setMessage(getString(R.string.confirmation_message));
+                builder.setMessage(getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message2));
 
-            AlertDialog errorDialog = builder.create();
-            errorDialog.show(); // display the Dialog
+
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+
+            }
+            else
+            {
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.no_comrade_title); // title bar string
+                builder.setPositiveButton(R.string.ok, null);
+
+                builder.setMessage(R.string.no_comrade_msg);
+                AlertDialog errorDialog = builder.create();
+                errorDialog.show(); // display the Dialog
+            }
 
         }catch (Exception e)
         {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,5 +131,9 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
+    <string name="confirmation_message1">This message has been sent to</string>
+    <string name="confirmation_message2">registered Comrades</string>
+    <string name="no_comrade_title">No Comrades Registered</string>
+    <string name="no_comrade_msg">Message not send to any comrade, since none is registered</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="message_failed">Message Sending Failed, Try again Later</string>
     <string name="no_phone_number">No phone number found</string>
     <string name="choose_number">Choose a number</string>
+    <string name="circle_of_trust_slide_two">When you are feeling insecure or need comrades\' attention.\nPress the button</string>
     <string name="confirmation_message1">This message has been sent to</string>
     <string name="confirmation_message2">registered Comrades</string>
     <string name="no_comrade_title">No Comrades Registered</string>


### PR DESCRIPTION


If no comrade have been added and the user presses the help me button, then a dialog box appears notifying the user that no message has been sent since no comrades were registered.

![screenshot_2016-03-01-01-56-51](https://cloud.githubusercontent.com/assets/8321130/13410777/9bd7dc84-df5f-11e5-8720-6d52255cd08c.png)

In the confirmation dialog displayed after the messages are sent, the number of comrades to whom the message has been sent is displayed now

![screenshot_2016-03-01-02-22-37](https://cloud.githubusercontent.com/assets/8321130/13410808/bb741a1c-df5f-11e5-9e46-d3bcbc27544b.png)


