### PR TITLE
Different shades for edited text and saved text.

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.text.Html;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -59,31 +60,30 @@ public class Trustees extends AppCompatActivity {
         sharedpreferences = getSharedPreferences(MyPREFERENCES, Context.MODE_PRIVATE);
         editor = sharedpreferences.edit();
 
-        comrade1editText.setText(sharedpreferences.getString(comrade1, ""));
-        comrade2editText.setText(sharedpreferences.getString(comrade2, ""));
-        comrade3editText.setText(sharedpreferences.getString(comrade3, ""));
-        comrade4editText.setText(sharedpreferences.getString(comrade4, ""));
-        comrade5editText.setText(sharedpreferences.getString(comrade5, ""));
-        comrade6editText.setText(sharedpreferences.getString(comrade6, ""));
-
+        comrade1editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade1, "") + "</font>"));
+        comrade2editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade2, "") + "</font>"));
+        comrade3editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade3, "") + "</font>"));
+        comrade4editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade4, "") + "</font>"));
+        comrade5editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade5, "") + "</font>"));
+        comrade6editText.setText(Html.fromHtml("<font color='black'>" + sharedpreferences.getString(comrade6, "") + "</font>"));
 
         okButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                boolean check_duplicate_number= check_duplicate_number();
+                boolean check_duplicate_number = check_duplicate_number();
 
                 //To store previous values (numbers) of comrades
-                String old_comrade1,old_comrade2,old_comrade3,old_comrade4,old_comrade5,old_comrade6;
+                String old_comrade1, old_comrade2, old_comrade3, old_comrade4, old_comrade5, old_comrade6;
 
                 //To store newly entered values (numbers) of comrades, if any
-                String new_comrade1,new_comrade2,new_comrade3,new_comrade4,new_comrade5,new_comrade6;
+                String new_comrade1, new_comrade2, new_comrade3, new_comrade4, new_comrade5, new_comrade6;
 
                 //Retrieving stored values
-                old_comrade1 = sharedpreferences.getString(comrade1,"");
-                old_comrade2 = sharedpreferences.getString(comrade2,"");
-                old_comrade3 = sharedpreferences.getString(comrade3,"");
-                old_comrade4 = sharedpreferences.getString(comrade4,"");
-                old_comrade5 = sharedpreferences.getString(comrade5,"");
+                old_comrade1 = sharedpreferences.getString(comrade1, "");
+                old_comrade2 = sharedpreferences.getString(comrade2, "");
+                old_comrade3 = sharedpreferences.getString(comrade3, "");
+                old_comrade4 = sharedpreferences.getString(comrade4, "");
+                old_comrade5 = sharedpreferences.getString(comrade5, "");
                 old_comrade6 = sharedpreferences.getString(comrade6, "");
 
                 //Retrieving new values
@@ -108,13 +108,11 @@ public class Trustees extends AppCompatActivity {
                     if (status) {
 
                         //Check if any updation is required
-                        if(old_comrade1.equals(new_comrade1) && old_comrade2.equals(new_comrade2) && old_comrade3.equals(new_comrade3) && old_comrade4.equals(new_comrade4) &&
-                                old_comrade5.equals(new_comrade5) && old_comrade6.equals(new_comrade6))
-                        {
+                        if (old_comrade1.equals(new_comrade1) && old_comrade2.equals(new_comrade2) && old_comrade3.equals(new_comrade3) && old_comrade4.equals(new_comrade4) &&
+                                old_comrade5.equals(new_comrade5) && old_comrade6.equals(new_comrade6)) {
                             //Nothing to update
                             Toast.makeText(getApplicationContext(), getString(R.string.not_updated_phone_numbers), Toast.LENGTH_LONG).show();
-                        }
-                        else {
+                        } else {
                             //Need to update
                             Toast.makeText(getApplicationContext(), getString(R.string.updated_phone_numbers), Toast.LENGTH_LONG).show();
                         }
@@ -126,13 +124,20 @@ public class Trustees extends AppCompatActivity {
                         Toast.makeText(getApplicationContext(), getString(R.string.updated_phone_numbers_fail), Toast.LENGTH_LONG).show();
                     }
 
-                }
-                else
-                {
+                } else {
                     Toast.makeText(getApplicationContext(), getString(R.string.duplicate_number_errormessage), Toast.LENGTH_LONG).show();
                 }
             }
         });
+
+        //Function to show cursor on being clicked
+        comrade1editText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                comrade1editText.setCursorVisible(true);
+            }
+        });
+
     }
 
     public void addContact(View v) {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <color name="fragment_safety_resource_text_color">#fff</color>
     <color name="activity_trustee_background">#2FAA96</color>
     <color name="activity_trustee_text_color">#fffaf3f1</color>
-    <color name="activity_trustee_edittext_color">#000</color>
+    <color name="activity_trustee_edittext_color">#2FAA96</color>
     <color name="photo_border">#FFFFFF</color>
     <color name="Title_color">#ffff</color>
     <color name="text_color_link">#024002</color>


### PR DESCRIPTION
Fixes Issue #144 
Numbers edited are shown in greenish shade. 
![screenshot_2016-03-13-00-02-25](https://cloud.githubusercontent.com/assets/8321130/13724640/4b13132a-e8b2-11e5-843b-e4ef2646a797.png)

Hence, the user will know what has he/she edited.
