### PR TITLE
2 other Alert Dialogs in CircleOfTrust were facing similar recreation issues

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -1,6 +1,5 @@
 package com.peacecorps.pcsa.circle_of_trust;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -157,32 +156,20 @@ public class CircleOfTrustFragment extends Fragment {
             }
             if(counter!=0)
             {
-                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                builder.setTitle(R.string.msg_sent); // title bar string
-                builder.setPositiveButton(R.string.ok, null);
+                String contentToPost;
 
                 //For 1 comrade
                 if(counter == 1)
-                    builder.setMessage(getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message3));
+                    contentToPost = getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message3);
                 else
-                    builder.setMessage(getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message2));
-
-
-
-
-                AlertDialog errorDialog = builder.create();
-                errorDialog.show(); // display the Dialog
-
+                    contentToPost = getString(R.string.confirmation_message1)+ " " + counter + " "+ getString(R.string.confirmation_message2);
+                CustomAlertDialogFragment customAlertDialogFragment = CustomAlertDialogFragment.newInstance(getString(R.string.msg_sent),contentToPost);
+                customAlertDialogFragment.show(getActivity().getSupportFragmentManager(),getString(R.string.dialog_tag));
             }
             else
             {
-                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                builder.setTitle(R.string.no_comrade_title); // title bar string
-                builder.setPositiveButton(R.string.ok, null);
-
-                builder.setMessage(R.string.no_comrade_msg);
-                AlertDialog errorDialog = builder.create();
-                errorDialog.show(); // display the Dialog
+                CustomAlertDialogFragment customAlertDialogFragment = CustomAlertDialogFragment.newInstance(getString(R.string.no_comrade_title),getString(R.string.no_comrade_msg));
+                customAlertDialogFragment.show(getActivity().getSupportFragmentManager(),getString(R.string.dialog_tag));
             }
 
         }catch (Exception e)

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CustomAlertDialogFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CustomAlertDialogFragment.java
@@ -1,0 +1,44 @@
+package com.peacecorps.pcsa.circle_of_trust;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+import com.peacecorps.pcsa.R;
+
+/**
+ * Created by Rohan on 13-03-2016.
+ * A template for alert dialogs which display the user about confirmation of message being sent to the comrades
+ */
+public class CustomAlertDialogFragment extends DialogFragment {
+
+    public static CustomAlertDialogFragment newInstance(String title, String content)
+    {
+        CustomAlertDialogFragment customAlertDialogFragment = new CustomAlertDialogFragment();
+        Bundle args = new Bundle();
+        args.putString("title",title);
+        args.putString("content", content);
+        customAlertDialogFragment.setArguments(args);
+        return customAlertDialogFragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        String title = getArguments().getString("title");
+        String content = getArguments().getString("content");
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+
+        // title bar string
+        builder.setTitle(title);
+        builder.setPositiveButton(R.string.ok, null);
+
+        builder.setMessage(content);
+        AlertDialog errorDialog = builder.create();
+        // return the Dialog object
+        return errorDialog;
+    }
+}

--- a/app/src/main/java/com/peacecorps/pcsa/reporting/ContactOptionsDialogBox.java
+++ b/app/src/main/java/com/peacecorps/pcsa/reporting/ContactOptionsDialogBox.java
@@ -1,0 +1,71 @@
+package com.peacecorps.pcsa.reporting;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.Window;
+import android.widget.AdapterView;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.peacecorps.pcsa.R;
+
+/**
+ * Created by Rohan on 13-03-2016.
+ */
+public class ContactOptionsDialogBox extends DialogFragment {
+
+    private static Context context;
+    private Dialog listDialog;
+    public static ContactOptionsDialogBox newInstance(String title, Activity activity)
+    {
+        context = (Context)activity;
+        ContactOptionsDialogBox customAlertDialogFragment = new ContactOptionsDialogBox();
+        Bundle args = new Bundle();
+        args.putString("title",title);
+        customAlertDialogFragment.setArguments(args);
+        return customAlertDialogFragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        String title = getArguments().getString("title");
+        //Initialising the dialog box
+        listDialog = new Dialog(context);
+        listDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        listDialog.getWindow().setBackgroundDrawable(new ColorDrawable(android.graphics.Color.TRANSPARENT));
+        LayoutInflater layoutInflater = LayoutInflater.from(context);
+
+        //Initialising the listview
+        View view = layoutInflater.inflate(R.layout.dialog_list, null);
+        listDialog.setContentView(view);
+        ListView list1 = (ListView) listDialog.findViewById(R.id.dialog_listview);
+
+        //Adding the header(title) to the dialog box
+        TextView textView = new TextView(context);
+        textView.setText(title);
+        textView.setTextColor(context.getResources().getColor(R.color.primary_text_default_material_dark));
+        textView.setTypeface(Typeface.DEFAULT_BOLD);
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_SP,20);
+        textView.setGravity(Gravity.CENTER);
+        list1.addHeaderView(textView);
+
+        list1.setAdapter(new CustomAdapter(context));
+
+        //Providing functionality to the listitems (Call and Message)
+        list1.setOnItemClickListener((AdapterView.OnItemClickListener) context);
+
+        return listDialog;
+    }
+}

--- a/app/src/main/java/com/peacecorps/pcsa/reporting/ContactPostStaff.java
+++ b/app/src/main/java/com/peacecorps/pcsa/reporting/ContactPostStaff.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.FragmentActivity;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.widget.AdapterView;
@@ -29,7 +30,7 @@ import java.util.Map;
  * Allows the user to call Post Staff in case of crime. The details for the
  * current location will be set by changing the location
  */
-public class ContactPostStaff extends Activity implements AdapterView.OnItemSelectedListener, AdapterView.OnItemClickListener {
+public class ContactPostStaff extends FragmentActivity implements AdapterView.OnItemSelectedListener, AdapterView.OnItemClickListener {
 
     private static final String PREF_LOCATION = "location" ;
 
@@ -74,7 +75,9 @@ public class ContactPostStaff extends Activity implements AdapterView.OnItemSele
             @Override
             public void onClick(View v) {
                 numberToContact = selectedLocationDetails.getPcmoContact();
-                CustomAdapter.createDialog(getString(R.string.contact_pcmo_via), ContactPostStaff.this).show();
+                ContactOptionsDialogBox contactOptionsDialogBox = ContactOptionsDialogBox.newInstance(getString(R.string.contact_pcmo_via),
+                        ContactPostStaff.this);
+                contactOptionsDialogBox.show(getSupportFragmentManager(),getString(R.string.dialog_tag));
             }
         });
 
@@ -82,7 +85,9 @@ public class ContactPostStaff extends Activity implements AdapterView.OnItemSele
             @Override
             public void onClick(View v) {
                 numberToContact = selectedLocationDetails.getSsmContact();
-                CustomAdapter.createDialog(getString(R.string.contact_ssm_via), ContactPostStaff.this).show();
+                ContactOptionsDialogBox contactOptionsDialogBox = ContactOptionsDialogBox.newInstance(getString(R.string.contact_ssm_via),
+                        ContactPostStaff.this);
+                contactOptionsDialogBox.show(getSupportFragmentManager(), getString(R.string.dialog_tag));
             }
         });
 
@@ -90,7 +95,9 @@ public class ContactPostStaff extends Activity implements AdapterView.OnItemSele
             @Override
             public void onClick(View v) {
                 numberToContact = selectedLocationDetails.getSarlContact();
-                CustomAdapter.createDialog(getString(R.string.contact_sarl_via), ContactPostStaff.this).show();
+                ContactOptionsDialogBox contactOptionsDialogBox = ContactOptionsDialogBox.newInstance(getString(R.string.contact_sarl_via),
+                        ContactPostStaff.this);
+                contactOptionsDialogBox.show(getSupportFragmentManager(), getString(R.string.dialog_tag));
             }
         });
 

--- a/app/src/main/java/com/peacecorps/pcsa/reporting/OtherStaffContent.java
+++ b/app/src/main/java/com/peacecorps/pcsa/reporting/OtherStaffContent.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.widget.AdapterView;
@@ -20,7 +21,7 @@ import com.peacecorps.pcsa.R;
  * Shows details of the Other Staff members to contact in case of crime
  * Allows user to call/send SMS to Other Staff members
  */
-public class OtherStaffContent extends Activity implements AdapterView.OnItemClickListener {
+public class OtherStaffContent extends FragmentActivity implements AdapterView.OnItemClickListener {
 
     public static final String CONTACT_NUMBER = "contactNumber";
     public static final String CONTACT_NAME = "contactName";
@@ -45,11 +46,12 @@ public class OtherStaffContent extends Activity implements AdapterView.OnItemCli
         contactName.setText(details.getString(CONTACT_NAME));
         contactDescription.setText(details.getString(CONTACT_DESC));
         contactNow.setText("Contact Now");
-
         contactNow.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                CustomAdapter.createDialog(getString(R.string.contact)+" "+details.getString(CONTACT_NAME)+" "+getString(R.string.via),OtherStaffContent.this).show();
+                ContactOptionsDialogBox contactOptionsDialogBox = ContactOptionsDialogBox.newInstance(getString(R.string.contact)+" "+details.getString(CONTACT_NAME)+" "+getString(R.string.via),
+                        OtherStaffContent.this);
+                contactOptionsDialogBox.show(getSupportFragmentManager(), getString(R.string.dialog_tag));
             }
         });
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="updated_phone_numbers">"Comrades' phone numbers have been updated"</string>
     <string name="not_updated_phone_numbers">No changes detected</string>
     <string name="updated_phone_numbers_fail">"Unable to update Comrades' phone numbers"</string>
+    <string name="dialog_tag">Alert_Dialog</string>
 
 
 </resources>


### PR DESCRIPTION
Failed to notice this earlier, but all the dialog boxes in the app (3 of them in Circle Of Trust and 1 in Reporting Process, totally 4 ) are having similar recreation issues. 
Had fixed one earlier. This PR fixes this issue for the other 2 in CircleOfTrust. 
Will fix the other one (existing in reporting process) soon since it requires different implementation and add it as another commit to the same PR