### PR TITLE
Save button executes on one click. 

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -61,7 +61,6 @@ public class Trustees extends AppCompatActivity {
 
         okButton = (Button) findViewById(R.id.okButton);
         okButton.setFocusable(true);
-        okButton.setFocusableInTouchMode(true);
 
         sharedpreferences = getSharedPreferences(MY_PREFERENCES, Context.MODE_PRIVATE);
         editor = sharedpreferences.edit();


### PR DESCRIPTION
The problem no longer exists.
Try by pressing the <b>Save</b> button in Add Trustees screen. It also retains focus so that the keyboard doesn't appear.