### PR TITLE
Navigation bar improved #313

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/MainActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/MainActivity.java
@@ -60,6 +60,7 @@ public class MainActivity extends AppCompatActivity {
     public static String FRAGMENT_TAG = MainActivityFragment.TAG;
     private FragmentManager fragmentManager = getSupportFragmentManager();
     SharedPreferences sharedPreferences;
+    private int lastExpandedGroup=-1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -91,11 +92,10 @@ public class MainActivity extends AppCompatActivity {
         prepareListData();
         listAdapter = new NavDrawerListAdapter(this, listDataHeader, listDataChild);
         expListView.setAdapter(listAdapter);
-        expListView.setOnGroupExpandListener(new ExpandableListView.OnGroupExpandListener() {
+        expListView.setOnGroupClickListener(new ExpandableListView.OnGroupClickListener() {
             @Override
-            public void onGroupExpand(int groupPosition) {
-                switch (groupPosition)
-                {
+            public boolean onGroupClick(ExpandableListView parent, View v, int groupPosition, long id) {
+                switch (groupPosition) {
                     case 0:
                         //Swapping ContactPostStaff into the fragment container dynamically
                         Fragment contactPostStaffFragment = new ContactPostStaff();
@@ -116,9 +116,19 @@ public class MainActivity extends AppCompatActivity {
                     case 7:
                         Toast.makeText(MainActivity.this,getString(R.string.change_name),Toast.LENGTH_LONG).show();
                 }
+                return false;
             }
         });
-
+        expListView.setOnGroupExpandListener(new ExpandableListView.OnGroupExpandListener() {
+            @Override
+            public void onGroupExpand(int groupPosition) {
+                if (lastExpandedGroup != -1
+                        && groupPosition != lastExpandedGroup) {
+                    expListView.collapseGroup(lastExpandedGroup);
+                }
+                lastExpandedGroup = groupPosition;
+            }
+        });
         expListView.setOnChildClickListener(new ExpandableListView.OnChildClickListener() {
             @Override
             public boolean onChildClick(ExpandableListView parent, View v, int groupPosition, int childPosition, long id) {


### PR DESCRIPTION
@rohands @sandarumk  I have solved the problem as described in #313. Changes made are -

1. Replaced setOnGroupExpandListener by setOnGroupClickListener which was creating need for double touching the item to open it.
2. Ensured that any other expanded group collapse when new group is expanded (Implemented this in setOnGroupExpandListener).

