### PR TITLE
Transition slides down instead of right on Contact Post Staff screen

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/MainActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/MainActivity.java
@@ -21,6 +21,7 @@ import android.widget.ExpandableListView;
 import android.widget.Toast;
 
 import com.peacecorps.pcsa.circle_of_trust.CircleOfTrustFragment;
+import com.peacecorps.pcsa.get_help_now.ContactOtherStaff;
 import com.peacecorps.pcsa.get_help_now.ContactPostStaff;
 import com.peacecorps.pcsa.policies_glossary.FurtherResourcesFragment;
 import com.peacecorps.pcsa.policies_glossary.GlossaryFragment;
@@ -255,18 +256,29 @@ public class MainActivity extends AppCompatActivity {
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         // Insert the fragment by replacing any existing fragment
         FRAGMENT_TAG = TAG;
+        int animEnter = R.anim.push_down_in;
+        int animExit = R.anim.push_down_out;
+        int animPopEnter = R.anim.fade_in;
+        int animPopExit = R.anim.fade_out;
+
         if(addToBackStack){
+            if (TAG.equals(ContactOtherStaff.TAG)) {
+                animEnter = R.anim.fade_in;
+                animExit = R.anim.fade_out;
+                animPopEnter = R.anim.fade_in_back;
+                animPopExit = R.anim.fade_out_back;
+            }
             fragmentManager.beginTransaction()
-                    .setCustomAnimations(R.anim.push_down_in,R.anim.push_down_out,R.anim.fade_in,R.anim.fade_out)
+                    .setCustomAnimations(animEnter, animExit, animPopEnter, animPopExit)
                     .replace(R.id.fragment_container
                             , fragment,TAG)
                     .addToBackStack(TAG)
                     .commit();
-        }
-        else
-        {
+        } else {
+            animEnter = R.anim.fade_in;
+            animExit = R.anim.fade_out;
             fragmentManager.beginTransaction()
-                    .setCustomAnimations(R.anim.fade_in,R.anim.fade_out,R.anim.fade_in,R.anim.fade_out)
+                    .setCustomAnimations(animEnter, animExit, animPopEnter, animPopExit)
                     .replace(R.id.fragment_container
                             , fragment,TAG)
                     .commit();

--- a/app/src/main/res/anim/fade_in_back.xml
+++ b/app/src/main/res/anim/fade_in_back.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <translate
+        android:fromXDelta="-100%" android:toXDelta="0%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="700" />
+</set>

--- a/app/src/main/res/anim/fade_out_back.xml
+++ b/app/src/main/res/anim/fade_out_back.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <translate
+        android:fromXDelta="0%" android:toXDelta="100%"
+        android:fromYDelta="0%" android:toYDelta="0%"
+        android:duration="700"/>
+</set>


### PR DESCRIPTION
Fixed issue [#275](https://github.com/systers/FirstAide-Android/issues/275).

PS: I had to make those 2 anim files fade_in_back and fade_out_back. Without them, it would slide right to Contact Others, but will also SLIDE RIGHT when coming back to Contact Post Staff Screen.