### PR TITLE
Fix action bar height when edits include keyboard.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
             android:name=".UserSettingsActivity"
             android:label="@string/user_settings_activity"
             android:parentActivityName=".MainActivity"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="adjustPan|stateAlwaysHidden">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.peacecorps.pcsa.MainActivity" />


### PR DESCRIPTION
Fix for #292 User Settings bar changes height on Name edit.  Updated AndroidManifest to preserve background.  Additionally, hide keyboard when clicked away.

Before on the left and after on the right when clicking on name:
![nameclick](https://cloud.githubusercontent.com/assets/22982909/21243952/278c29fc-c2d0-11e6-8049-291cbf4ed482.gif)

Before on the left and after on the right when clicking in the background:
![backgroundkeyboard](https://cloud.githubusercontent.com/assets/22982909/21243992/4cb5c79c-c2d0-11e6-908d-c4df768351fb.jpg)

