### PR TITLE
#338 App crash in Intro Slides - "Done" Textview Bug solved

### DIFF
--- a/app/src/main/res/layout/intro4.xml
+++ b/app/src/main/res/layout/intro4.xml
@@ -48,7 +48,6 @@
         android:textSize="@dimen/text_large"
         android:textStyle="bold"
         android:fontFamily="sans-serif-thin"
-        android:onClick="getStarted"
         android:text="@string/slide_four_bottom"/>
     <TextView
         android:layout_width="fill_parent"


### PR DESCRIPTION
#338 As discussed in the issue making "Done" Textview unclickable (just for indication that user is done with intro slides).