### PR TITLE
Fix : Name Box remains empty #350

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/UserSettingsActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/UserSettingsActivity.java
@@ -75,13 +75,33 @@ public class UserSettingsActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences,final String key) {
+
+            EditTextPreference editTextPreference = (EditTextPreference) getPreferenceScreen().findPreference(
+                    "NAME");
+            editTextPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(
+                        android.preference.Preference preference, Object newValue) {
+
+                    if (newValue.toString().trim().equals("")) {
+
+                        Toast.makeText(getActivity(), R.string.valid_name,
+                                Toast.LENGTH_SHORT).show();
+
+                        return false;
+                    }else if(!newValue.toString().matches("^[a-zA-Z ]*$")){
+                        Toast.makeText(getActivity(),R.string.prompt_please_valid, Toast.LENGTH_SHORT).show();
+                        return false;
+                    }
+                    return true;
+                }
+            });
+
             if("".equals(sharedPreferences.getString(key,"").trim())){
-                Toast.makeText(getActivity(),R.string.valid_name, Toast.LENGTH_SHORT).show();
                 return;
             }
             else if(!sharedPreferences.getString(key,"").matches("^[a-zA-Z ]*$")){
-                Toast.makeText(getActivity(),R.string.prompt_please_valid, Toast.LENGTH_SHORT).show();
                 return;
             }
             else


### PR DESCRIPTION
#350 
I have added another check in the method.
If one saves the Name as empty in User Settings, it will show "Enter a valid name" . If it is clicked again, it will not show an empty box. It will populate the former correct one.
I have added a validation to the editText Field in the dialogbox. 