### PR TITLE
Fixes#381:Wrong Status Bar Color in CircleOfTrust and SignUp Activity

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/SignupActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/SignupActivity.java
@@ -2,11 +2,14 @@ package com.peacecorps.pcsa;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -34,6 +37,11 @@ public class SignupActivity extends AppCompatActivity  implements AdapterView.On
         setContentView(R.layout.activity_login);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.status_bar_color));
+        }
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(SignupActivity.this);

--- a/app/src/main/java/com/peacecorps/pcsa/SignupActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/SignupActivity.java
@@ -37,11 +37,8 @@ public class SignupActivity extends AppCompatActivity  implements AdapterView.On
         setContentView(R.layout.activity_login);
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-            getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.status_bar_color));
-        }
+        //This method will change the status bar color by checking the android version
+        StatusBarColorUtil.changeStatusBarColor(this,getWindow());
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(SignupActivity.this);

--- a/app/src/main/java/com/peacecorps/pcsa/StatusBarColorUtil.java
+++ b/app/src/main/java/com/peacecorps/pcsa/StatusBarColorUtil.java
@@ -1,0 +1,25 @@
+package com.peacecorps.pcsa;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.support.v4.content.ContextCompat;
+import android.view.Window;
+import android.view.WindowManager;
+
+/**
+ * Created by HIman$hu on 3/7/2017.
+ */
+
+public class StatusBarColorUtil {
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public static void changeStatusBarColor(Context context, Window window) {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar_color));
+        }
+    }
+}

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 
 import com.peacecorps.pcsa.MainActivity;
 import com.peacecorps.pcsa.R;
+import com.peacecorps.pcsa.StatusBarColorUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,11 +63,8 @@ public class Trustees extends AppCompatActivity {
 
         toolbar = (Toolbar)findViewById(R.id.toolbar_trustees);
         setSupportActionBar(toolbar);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-            getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.status_bar_color));
-        }
+        //This method will change the status bar color by checking the android version
+        StatusBarColorUtil.changeStatusBarColor(this,getWindow());
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         getSupportActionBar().setTitle(R.string.title_activity_trustees);

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -5,16 +5,19 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.ContactsContract;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
@@ -59,6 +62,11 @@ public class Trustees extends AppCompatActivity {
 
         toolbar = (Toolbar)findViewById(R.id.toolbar_trustees);
         setSupportActionBar(toolbar);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.status_bar_color));
+        }
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setDisplayShowHomeEnabled(true);
         getSupportActionBar().setTitle(R.string.title_activity_trustees);

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <!-- Background colors-->
     <color name="background_app">#05D197</color>
     <color name="background_textview">#02845F</color>
+    <color name="status_bar_color">#02845F</color>
     <color name="background_clicked">#FFC25C</color>
     <color name="background_fragment_circle_of_trust">#05D197</color>
     <color name="intro_background">#ffdfb68a</color>


### PR DESCRIPTION
Fixes #381 

**Fix**
Changing the Status Bar color in pre-Lollipop(5.0) is not possible by setting colorPrimaryDark as mention in this [Android Developers Blog.](https://android-developers.googleblog.com/2014/10/appcompat-v21-material-design-for-pre.html)

So I checked the version and change the **status bar color** programmatically in Trustees and SignUpActivity.java 

**ScreenShot**
![untitled-1](https://cloud.githubusercontent.com/assets/18090596/23360092/811c32e0-fd0f-11e6-9a31-bd4072a82eeb.png)

@sandarumk Please review this PR.
Thank You