### PR TITLE
Fix App crash on message report in CircleOfTrust

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,9 @@
                             android:name="android.support.PARENT_ACTIVITY"
                             android:value="com.peacecorps.pcsa.MainActivity" />
         </activity>
+        <activity android:name=".circle_of_trust.SMSReportDialogActivity"
+            android:theme="@android:style/Theme.Holo.Light.Dialog">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/peacecorps/pcsa/Constants.java
+++ b/app/src/main/java/com/peacecorps/pcsa/Constants.java
@@ -8,6 +8,7 @@ public class Constants {
         public static final String COME_GET_ME = "Come get me";
         public static final String CALL_NEED_INTERRUPTION = "Call I need an interruption";
         public static final String NEED_TO_TALK = "I need to talk";
+        public static final String SMS_REPORT = "SMS report";
     }
 
     public static final String TAG_LOCATION = "#LOC#";

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/CircleOfTrustFragment.java
@@ -5,14 +5,10 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.location.Location;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.os.Vibrator;
-import android.provider.Settings;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.telephony.SmsManager;
@@ -135,14 +131,17 @@ public class CircleOfTrustFragment extends Fragment {
                             if(!sent.get(i))
                                 logMessage += numbers[i] + " : " + getString(R.string.sms_send_pass);
                             else
-                                logMessage += numbers[i] + " : " + getString(R.string.sms_send_fail);
+                                logMessage += numbers[i] + " : " + context.getString(R.string.sms_send_fail);
                             logMessage += "\n";
                         }
 
                     }
-                    CustomAlertDialogFragment customAlertDialogFragment = CustomAlertDialogFragment.newInstance(getString(R.string.log_title),logMessage);
-                    customAlertDialogFragment.show(getActivity().getSupportFragmentManager(),getString(R.string.dialog_tag));
                     sent.clear();
+                    //starts the dialog activity which will show the report
+                    Intent intent1 = new Intent(context,SMSReportDialogActivity.class);
+                    intent1.putExtra(SmsConstants.SMS_REPORT,logMessage);
+                    context.startActivity(intent1);
+
                 }
             }
         };

--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/SMSReportDialogActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/SMSReportDialogActivity.java
@@ -1,0 +1,48 @@
+package com.peacecorps.pcsa.circle_of_trust;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.TextView;
+
+import com.peacecorps.pcsa.Constants;
+import com.peacecorps.pcsa.R;
+
+public class SMSReportDialogActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        setContentView(R.layout.activity_dialog);
+
+        //adjusts the width of dialog
+        Rect displayRectangle = new Rect();
+        getWindow().getDecorView().getWindowVisibleDisplayFrame(displayRectangle);
+        WindowManager.LayoutParams params = getWindow().getAttributes();
+        params.width = (int) (displayRectangle.width() * 0.9);
+        this.getWindow().setAttributes(params);
+
+        //takes the message report from intent
+        Intent intent = getIntent();
+        String msgLog= intent.getStringExtra(Constants.SmsConstants.SMS_REPORT);
+        TextView dialogTitle = (TextView) findViewById(R.id.title);
+        TextView dialogContent = (TextView) findViewById(R.id.content);
+        dialogTitle.setText(getResources().getString(R.string.log_title));
+        dialogContent.setText(msgLog);
+        TextView confirmButton = (TextView) findViewById(R.id.confirm);
+        confirmButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                finish();
+            }
+        });
+
+
+
+    }
+}

--- a/app/src/main/res/layout/activity_dialog.xml
+++ b/app/src/main/res/layout/activity_dialog.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/dialog_title_marginBottom"
+        android:layout_marginLeft="@dimen/dialog_title_marginLeft"
+        android:layout_marginTop="@dimen/dialog_title_marginTop"
+        android:textSize="@dimen/dialog_title_textSize"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/content"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="@dimen/dialog_content_marginBottom"
+        android:layout_marginLeft="@dimen/dialog_title_marginLeft" />
+
+    <TextView
+        android:id="@+id/confirm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:layout_marginBottom="@dimen/dialog_title_marginBottom"
+        android:layout_marginRight="@dimen/dialog_marginRight"
+        android:text="@string/dialog_ok"
+        android:textAlignment="textEnd"
+        android:textColor="@color/background_app"
+        android:textSize="@dimen/dialog_textSize" />
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -116,5 +116,12 @@
     <dimen name="safety_plan_marginTop">20dp</dimen>
     <dimen name="sub_title_font_trustee">28sp</dimen>
     <dimen name="navgn_bar_marginRight">0dp</dimen>
+    <dimen name="dialog_title_textSize">20sp</dimen>
+    <dimen name="dialog_title_marginLeft">10dp</dimen>
+    <dimen name="dialog_title_marginTop">10dp</dimen>
+    <dimen name="dialog_title_marginBottom">40dp</dimen>
+    <dimen name="dialog_marginRight">10dp</dimen>
+    <dimen name="dialog_content_marginBottom">20dp</dimen>
+    <dimen name="dialog_textSize">15sp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,4 +228,5 @@
     <string name="theft">Theft</string>
     <string name="vulnerability">Vulnerability</string>
     <string name="lookup_important_words">Lookup important words</string>
+    <string name="dialog_ok">OK</string>
 </resources>


### PR DESCRIPTION
@sandarumk 
#383 I have added the DialogActivity SMS Report which will be opened when response is received in onReceive() of BroadcastReceiver. This dialog will be shown even if user is on some other activity or not even in the app.
<img src="https://cloud.githubusercontent.com/assets/13872065/23590976/29e180ca-020f-11e7-8988-cd6eee1f2d0b.jpeg" height="400" width="200">

I have also handled all screen sizes and dialog will also not vanish if screen orientation changes.
Please review :-)