### PR TITLE
Fixes #392:Settings button is missing in Trustees and SafetyPlanActivity Class

### DIFF
--- a/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
+++ b/app/src/main/java/com/peacecorps/pcsa/circle_of_trust/Trustees.java
@@ -15,6 +15,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
@@ -26,6 +28,7 @@ import android.widget.Toast;
 import com.peacecorps.pcsa.MainActivity;
 import com.peacecorps.pcsa.R;
 import com.peacecorps.pcsa.StatusBarColorUtil;
+import com.peacecorps.pcsa.UserSettingsActivity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -160,6 +163,12 @@ public class Trustees extends AppCompatActivity {
         }
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.settings,menu);
+        return true;
+    }
     /**
      * Start for selecting contacts from standard contract picker
      * @param v
@@ -369,10 +378,11 @@ public class Trustees extends AppCompatActivity {
         switch (item.getItemId()) {
             case android.R.id.home:
                 finish();
-                return true;
+            case R.id.menu_settings:
+                Intent intent=new Intent(this, UserSettingsActivity.class);
+                startActivity(intent);
         }
-
-        return super.onOptionsItemSelected(item);
+        return true;
     }
 }
 

--- a/app/src/main/java/com/peacecorps/pcsa/safety_tools/SafetyPlanActivity.java
+++ b/app/src/main/java/com/peacecorps/pcsa/safety_tools/SafetyPlanActivity.java
@@ -1,5 +1,6 @@
 package com.peacecorps.pcsa.safety_tools;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
@@ -8,9 +9,12 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import com.peacecorps.pcsa.R;
+import com.peacecorps.pcsa.UserSettingsActivity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,12 +46,22 @@ public class SafetyPlanActivity extends AppCompatActivity {
         tabLayout.setupWithViewPager(viewPager);
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.settings,menu);
+        return true;
+    }
+
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId())
         {
             case android.R.id.home:
                 this.finish();
                 break;
+            case R.id.menu_settings:
+                Intent intent=new Intent(this, UserSettingsActivity.class);
+                startActivity(intent);
         }
         return true;
     }


### PR DESCRIPTION
Fixes #392 

**Fix**
Added **setting** button in **Trustees** and **SafetyPlanActivity** class 

**Screenshot**
![device-2017-03-07-155402](https://cloud.githubusercontent.com/assets/18090596/23652352/9154626e-034e-11e7-9658-8f1b61b7b8bb.png)
![device-2017-03-07-155427](https://cloud.githubusercontent.com/assets/18090596/23652354/917216d8-034e-11e7-889b-d466c9199958.png)

@sandarumk Please review this PR.
Thanks :)
